### PR TITLE
"No Reviewer/ee Assignments" Email Notification to Instructors 

### DIFF
--- a/src/Review/Reviewing.php
+++ b/src/Review/Reviewing.php
@@ -561,6 +561,11 @@ MSG;
         $users = new Users($site->db);
 
         /*
+          * Create URL to assign reviewer/reviewees
+          */
+        $url = $site->server . $site->root . '/cl/console/review/reviewers/' . $this->assignment->tag;
+
+        /*
          * Create email contents
          */
         $message = <<<MSG
@@ -573,10 +578,6 @@ MSG;
          */
         $all = $members->getAllBySection($this->assignment->semester, $this->assignment->section->id);
 
-        /*
-         * Create URL to assign reviewer/reviewees
-         */
-        $url = $site->server . $site->root . '/cl/console/review/reviewers/' . $this->assignment->tag;
         $coursename = $site->siteName;
 
         $email = $this->__get('email');

--- a/src/Review/Reviewing.php
+++ b/src/Review/Reviewing.php
@@ -409,6 +409,14 @@ HTML;
             return false;
         }
 
+        /*
+         * If none of the students have been assigned to one-another, then email instructors
+         */
+        if (!$this->is_assigned()) {
+            // Email Instructors
+            $this->notifyMissingAssignments();
+        }
+
         // Get the reviewers for this submission
         $reviewAssignments = new ReviewAssignments($this->assignment->site->db);
         $reviewers = $reviewAssignments->getMemberReviewers($user->member->id, $this->assignment->tag);

--- a/src/Review/Reviewing.php
+++ b/src/Review/Reviewing.php
@@ -12,6 +12,9 @@ namespace CL\Review;
 use CL\Course\Assignment;
 use CL\Course\Member;
 use CL\Course\Members;
+use CL\Site\Api\JsonAPI;
+use CL\Site\Site;
+use CL\Site\System\Server;
 use CL\Users\User;
 use CL\Course\Submission\Submission;
 use CL\Course\Submission\Submissions;
@@ -159,7 +162,7 @@ class Reviewing {
      * @param $user the user that we will extract semester and sectionid information from
      * @return bool denoting if at least one reviewer/reviewee assignment has been made
      */
-    public function is_assigned(){
+    public function isAssigned(){
         /*
          * Get reviewers for this assignment
          */
@@ -178,6 +181,41 @@ class Reviewing {
         }
         return true;
     }
+
+    /**
+     * This function checks if the setting table shows that we have emailed instructors about no reviewer/ee assignments
+     * @return bool
+     * @throws \CL\Tables\TableException
+     */
+    public function hasNotifiedInstructors() {
+        /*
+        * Get semester, sectionId, and assignTag for this assignment
+        */
+        $site = $this->assignment->site;
+        $assignTag = $this->assignment->tag;
+        $reviewAssignments = new ReviewAssignments($site->db);
+        $semester =$this->assignment->semester;
+        $sectionId =$this->assignment->section->id;
+
+        /*
+         * Read from the setting data table
+         */
+        $settings = new \CL\Course\Settings($site->db);
+        $member = $user->member;
+        $setting = $settings->read('course', $semester, $sectionId,
+            'instructor-notifications', $assignTag);
+
+        /*
+         * If not notified, set the key 'notified' to true and return false, else return true
+         */
+        if (!$setting->get('notified')){
+            $setting->set('notified', false);
+            $settings->write($setting);
+            return false;
+        }
+        return true;
+    }
+
 
 //	/**
 //	 * Get the number of hours after a review that a user can revised
@@ -410,11 +448,14 @@ HTML;
         }
 
         /*
-         * If none of the students have been assigned to one-another, then email instructors
+         * If none of the instructors haven't been notified before,
+         * and students have been assigned to one-another, then email instructors
          */
-        if (!$this->is_assigned()) {
-            // Email Instructors
-            $this->notifyMissingAssignments();
+        if (!$this->hasNotifiedInstructors()){
+            if (!$this->isAssigned()) {
+                // Email Instructors
+                $this->notifyMissingAssignments();
+            }
         }
 
         // Get the reviewers for this submission
@@ -549,6 +590,17 @@ MSG;
                     "$coursename Peer Review Pairs: No Pairings Made", $message);
             }
         }
+
+        /*
+         * Write to the setting data table for this assignment and set "notified" to true
+         */
+        $settings = new \CL\Course\Settings($site->db);
+        $member = $user->member;
+        $setting = $settings->read('course', $this->assignment->semester, $this->assignment->section->id,
+            'instructor-notifications', $this->assignment->tag);
+
+        $setting->set('notified', true);
+        $settings->write($setting);
     }
 
 	/**

--- a/src/Review/Reviewing.php
+++ b/src/Review/Reviewing.php
@@ -586,7 +586,7 @@ MSG;
          */
         foreach($all as $member) {
             $user = $users->get($member->userId);
-            if($user->staff) {
+            if($user->role === User::ADMIN) {
                 $email->send($site, $user->email, $user->displayName,
                     "$coursename Peer Review Pairs: No Pairings Made", $message);
             }

--- a/src/Review/Reviewing.php
+++ b/src/Review/Reviewing.php
@@ -10,10 +10,13 @@
 namespace CL\Review;
 
 use CL\Course\Assignment;
+use CL\Course\Member;
+use CL\Course\Members;
 use CL\Users\User;
 use CL\Course\Submission\Submission;
 use CL\Course\Submission\Submissions;
 use CL\Site\Email;
+use CL\Users\Users;
 
 /**
  * Class that manages peer review for an assignment
@@ -149,6 +152,25 @@ class Reviewing {
 	 */
     public function after_due($time) {
         return $time > $this->due;
+    }
+
+    /**
+     * Boolean for denoting if at least one reviewer/reviewee assignment has been made
+     * @param $user the user that we will extract semester and sectionid information from
+     * @return bool denoting if at least one reviewer/reviewee assignment has been made
+     */
+    public function is_assigned(){
+        $site = $this->assignment->site;
+        $assignTag = $this->assignment->tag;
+        $reviewAssignments = new ReviewAssignments($site->db);
+        $semester =$this->assignment->semester;
+        $sectionId =$this->assignment->section->id;
+        $assignments = $reviewAssignments->getReviewers($semester, $sectionId, $assignTag);
+
+        if (!$assignments){
+            return false;
+        }
+        return true;
     }
 
 //	/**


### PR DESCRIPTION
I've implemented the feature of emailing instructors when a student submits a review assignment that has no reviewer/ee assignments made. Within the email is a link to where they instructors can assign the students manually.

I've implemented persisting the boolean `isNotified` to the `capstone-setting` table at the semester->course->section->assignment level. This prevents more than one of these notifications from being sent per assignment.

 I have also mentioned to our sponsor (Dr. Owen) the idea of possibly automatically assigning reviewer/ees to one another at the moment of the email notification being sent. Doing this would make persisting the isNotified boolean unneeded, though the automatic assignment feature will likely not be implemented.